### PR TITLE
fix: use HasPrefix for --url validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	if *URL != "" {
-		if !strings.Contains(*URL, "http://") || !strings.Contains(*URL, "https://") {
+		if !strings.HasPrefix(*URL, "http://") && !strings.HasPrefix(*URL, "https://") {
 			log.Fatalf("Please enter a valid URL!")
 		}
 		var successfulUrls []string


### PR DESCRIPTION
Use `HasPrefix` instead of `Contains` to validate URLs from CLI args.

Before:
```fish
 ./secretsnitch --url=https://docs.phase.dev/integrations --recursions=1

Secretsnitch - A lightning-fast secret scanner in Golang!
https://github.com/0x4f53/secretsnitch
Copyright © 2024 Owais Shaikh
2024/11/01 21:32:27 Please enter a valid URL!
```

After:
```fish
./secretsnitch --url=https://docs.phase.dev/integrations --recursions=1

Secretsnitch - A lightning-fast secret scanner in Golang!
https://github.com/0x4f53/secretsnitch
Copyright © 2024 Owais Shaikh
2024/11/01 21:33:09 Skipping https://docs.phase.dev/integrations as it is already cached at .urlCache/6b4913d9.cache
2024/11/01 21:33:09 Searching for secrets in: https://docs.phase.dev/integrations (cached at: .urlCache/6b4913d9.cache)
2024/11/01 21:33:09 Scanning 90 tokens for secrets
2024/11/01 21:33:10 Skipping https://docs.phase.dev as it is already cached at .urlCache/d8540436.cache
2024/11/01 21:33:10 Skipping https://docs.phase.dev/favicon.svg as it is already cached at .urlCache/9191cbd9.cache
2024/11/01 21:33:10 Skipping https://docs.phase.dev/_next/static/css/28ef76190d39bbac.css as it is already cached at .urlCache/dcefe868.cache
2024/11/01 21:33:10 Skipping https://docs.phase.dev/_next/static/chunks/polyfills-78c92fac7aa8fdd8.js as it is already cached at .urlCache/5b5664f6.cache
2024/11/01 21:33:10 Skipping https://docs.phase.dev/assets/asciinema/asciinema-player.min.js as it is already cached at .urlCache/242e40a9.cache
2024/11/01 21:33:10 Skipping https://docs.phase.dev/_next/static/chunks/webpack-440a5f58b8f79984.js as it is already cached at .urlCache/bace6e0c.cache
2024/11/01 21:33:10 Skipping https://docs.phase.dev/_next/static/chunks/framework-ae562e2278ed0cd0.js as it is already cached at .urlCache/f5b60f58.cache
```